### PR TITLE
Typo Fix in dig.cpp

### DIFF
--- a/plugins/dig.cpp
+++ b/plugins/dig.cpp
@@ -1274,7 +1274,7 @@ command_result digl (color_ostream &out, vector <string> & parameters)
     int16_t basemat = MCache->layerMaterialAt(xy);
     if( veinmat != -1 )
     {
-        con.printerr("This is a vein. Use vdig instead!\n");
+        con.printerr("This is a vein. Use digv instead!\n");
         delete MCache;
         return CR_FAILURE;
     }


### PR DESCRIPTION
Changed line 1277 to say "This is a vein. Use digv instead!/n" instead of "This is a vein. Use vdig instead!/n"